### PR TITLE
Address feedback on podcast page

### DIFF
--- a/src/components/EpisodeCard.js
+++ b/src/components/EpisodeCard.js
@@ -7,6 +7,9 @@ const Card = styled.div`
   border: 2px solid rgba(30, 30, 30, 1);
   border-radius: 18px;
 
+  max-width: 20rem;
+  min-width: 20rem;
+
   @media (min-width: 50rem) {
     max-width: 28rem;
     min-width: 28rem;
@@ -20,15 +23,19 @@ const Card = styled.div`
 const Content = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-
   color: var(--black);
-
   padding: 0.75rem;
 
   @media (min-width: 50rem) {
-    gap: 1rem;
     padding: 1rem 1rem;
+  }
+`
+
+const EpisodeDataContainer = styled.div`
+  margin-left: 0.75rem;
+
+  @media (min-width: 50rem) {
+    margin-left: 1rem;
   }
 `
 
@@ -37,7 +44,9 @@ const EpisodeCard = ({ episode }) => {
     <Card>
       <Content>
         <EpisodeImage src={episode.image} width={5} widthLarge={8} />
-        <EpisodeTitle episode={episode} />
+        <EpisodeDataContainer>
+          <EpisodeTitle episode={episode} />
+          </EpisodeDataContainer>
       </Content>
     </Card>
   )

--- a/src/components/EpisodePlayer.js
+++ b/src/components/EpisodePlayer.js
@@ -15,7 +15,6 @@ import {
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0;
 
   a {
     text-decoration: none;
@@ -46,28 +45,28 @@ const CardContentContainer = styled.div`
   padding: 0 1.2rem 1.2rem 1.2rem;
   color: var(--black);
   display: flex;
-  gap: 1rem;
   align-items: center;
 
   @media (min-width: 50rem) {
     padding: 0 1.2rem 1.5rem 1.2rem;
-    gap: 1.5rem;
   }
 `
 
 const EpisodeDataContainer = styled.div`
+  margin-left: 1rem;
+
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.2rem;
 
   @media (min-width: 50rem) {
+    margin-left: 1.5rem;
     max-width: 55%;
   }
 `
 
 const Value4ValueContainer = styled.div`
-  margin-top: 0.3rem;
+  margin-top: 0.5rem;
 `
 
 const renderCardContainer = (episode) => {

--- a/src/components/EpisodePlayerControls.js
+++ b/src/components/EpisodePlayerControls.js
@@ -51,6 +51,31 @@ const ProgressBar = styled.progress`
   height: 0.4rem;
   border: none;
   flex-grow: 1;
+
+  @media (max-width: 50rem) {
+    max-width: 30%; // fix for mobile firefox
+  }
+
+  @media (max-width: 23rem) {
+    max-width: 45%; // fix for mobile firefox
+  }
+
+  @media (max-width: 22rem) {
+    max-width: 40%; // fix for mobile firefox
+  }
+
+  @media (max-width: 21rem) {
+    max-width: 37%; // fix for mobile firefox
+  }
+
+  @media (max-width: 20rem) {
+    max-width: 33%; // fix for mobile firefox
+  }
+`
+
+const DurationDownloadContainer = styled.div`
+  display: flex;
+  align-items: baseline;
 `
 
 const DurationContainer = styled.div`
@@ -99,6 +124,12 @@ const DownloadLink = styled.a`
   }
 `
 
+const DownloadText = styled.span`
+  @media (max-width: 23rem) {
+    display: none;
+  }
+`
+
 const EpisodePlayerControls = ({ episode }) => {
   return (
     <Container>
@@ -107,24 +138,28 @@ const EpisodePlayerControls = ({ episode }) => {
         className="amplitude-song-played-progress"
         id="song-played-progress"
       />
-      <DurationContainer>
-        <CurrentDurationContainer>
-          <span className="amplitude-current-hours"></span>:
-          <span className="amplitude-current-minutes"></span>:
-          <span className="amplitude-current-seconds"></span>
-        </CurrentDurationContainer>
-        &nbsp;/&nbsp;
-        <TotalDurationContainer>
-          <span className="amplitude-duration-hours"></span>:
-          <span className="amplitude-duration-minutes"></span>:
-          <span className="amplitude-duration-seconds"></span>
-        </TotalDurationContainer>
-      </DurationContainer>
-      <DownloadLink>
-        <Link href={episode.url}>
-          <a>&#8595;&nbsp;Download</a>
-        </Link>
-      </DownloadLink>
+      <DurationDownloadContainer>
+        <DurationContainer>
+          <CurrentDurationContainer>
+            <span className="amplitude-current-hours"></span>:
+            <span className="amplitude-current-minutes"></span>:
+            <span className="amplitude-current-seconds"></span>
+          </CurrentDurationContainer>
+          &nbsp;/&nbsp;
+          <TotalDurationContainer>
+            <span className="amplitude-duration-hours"></span>:
+            <span className="amplitude-duration-minutes"></span>:
+            <span className="amplitude-duration-seconds"></span>
+          </TotalDurationContainer>
+        </DurationContainer>
+        <DownloadLink>
+          <Link href={episode.url}>
+            <a>
+            &#8595;<DownloadText>&nbsp;Download</DownloadText>
+            </a>
+          </Link>
+        </DownloadLink>
+      </DurationDownloadContainer>
     </Container>
   )
 }

--- a/src/components/EpisodeTitle.js
+++ b/src/components/EpisodeTitle.js
@@ -6,19 +6,26 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.2rem;
 `
 
 const MetadataContainer = styled.div`
   display: flex;
+  align-items: center;
   color: var(--gray);
-
+  text-align: left;
   font-size: 0.7rem;
-  gap: 0.3rem;
+  margin: 0 0 0.1rem 0;
 
   @media (min-width: 50rem) {
     font-size: 0.8rem;
-    gap: 0.4rem;
+  }
+`
+
+const MetadataSeparator = styled.span`
+  margin: 0 0.3rem 0 0.3rem;
+
+  @media (min-width: 50rem) {
+    margin: 0 0.4rem 0 0.4rem;
   }
 `
 
@@ -48,9 +55,9 @@ const EpisodeTitle = ({ episode }) => {
         <Text>
           S{episode.season} E{episode.episode}
         </Text>
-        <Text>&#8226;</Text>
+        <MetadataSeparator>&#8226;</MetadataSeparator>
         <Text>{formatEpisodeDuration(episode.duration)}</Text>
-        <Text>&#8226;</Text>
+        <MetadataSeparator>&#8226;</MetadataSeparator>
         <Text>{dateformat(episode.date, 'dd. mmm, yyyy')}</Text>
       </MetadataContainer>
       <TitleContainer>

--- a/src/components/Value4Value.js
+++ b/src/components/Value4Value.js
@@ -7,7 +7,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: 0.5rem;
   font-size: 0.7rem;
 
   @media (min-width: 50rem) {
@@ -22,6 +21,12 @@ const Recipient = styled.div`
   border-radius: 4px;
   color: var(--gray);
   cursor: pointer;
+
+  margin: 0 0 0.5rem 0;
+
+  @media (min-width: 50rem) {
+    margin: 0 0.5rem 0 0;
+  }
 `
 
 const getTooltipText = (recipient, recipients) => {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -20,11 +20,14 @@ const Buttons = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 2rem;
 
   @media (max-width: 50rem) {
     flex-direction: column;
   }
+`
+
+const ButtonWrapper = styled.div`
+  margin: 2rem;
 `
 
 const NotFoundPage = () => {
@@ -36,7 +39,9 @@ const NotFoundPage = () => {
       <Buttons>
         <Link href="/">
           <a>
-            <Button>Return home</Button>
+            <ButtonWrapper>
+              <Button>Return home</Button>
+            </ButtonWrapper>
           </a>
         </Link>
         <Button

--- a/src/pages/podcast/[id].js
+++ b/src/pages/podcast/[id].js
@@ -51,11 +51,10 @@ const DescriptionHeadingContainer = styled.div`
 `
 
 const DescriptionTextContainer = styled.div`
-  padding: 1.5rem 1.2rem;
+  padding: 1.5rem 1.5rem;
   margin-left: auto;
   margin-right: auto;
   font-size: 1rem;
-  font-weight: var(--weightLight);
   text-align: justify;
 
   border-radius: 0 0 18px 18px;
@@ -65,6 +64,16 @@ const DescriptionTextContainer = styled.div`
   a {
     color: var(--black);
     text-decoration: underline;
+  }
+
+  div {
+    p:not(:last-child) {
+      margin: 0 0 1rem 0;
+      line-height: 1.3;
+    }
+    ul:last-child {
+      margin-bottom: 0;
+    }
   }
 `
 

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -26,7 +26,7 @@ const Tagline = styled(Text)`
   }
 `
 
-const EpisodeContainer = styled.div`
+const EpisodePlayerContainer = styled.div`
   margin: 3rem 0 3rem 0;
 
   margin-left: auto;
@@ -44,16 +44,19 @@ const EpisodeContainer = styled.div`
 `
 
 const EpisodesContainer = styled.div`
-  padding: 3rem 0rem;
+  padding: 2rem 0rem;
   display: flex;
   flex-direction: row;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 2rem;
 
   a {
     text-decoration: none;
   }
+`
+
+const EpisodeContainer = styled.div`
+  margin: 1rem;
 `
 
 export default function Podcasts({ episodes }) {
@@ -81,12 +84,12 @@ export default function Podcasts({ episodes }) {
       <Bar height="12.5rem" />
 
       {episodes.length > 0 && (
-        <EpisodeContainer>
+        <EpisodePlayerContainer>
           <EpisodePlayer
             episode={episodes[0]}
             link={`/podcast/${episodes[0].slug}`}
           />
-        </EpisodeContainer>
+        </EpisodePlayerContainer>
       )}
 
       <Bar height="6.25rem" />
@@ -97,7 +100,9 @@ export default function Podcasts({ episodes }) {
             <Fragment key={index}>
               <Link href={`/podcast/${episode.slug}`}>
                 <a>
-                  <EpisodeCard episode={episode} />
+                  <EpisodeContainer>
+                    <EpisodeCard episode={episode} />
+                  </EpisodeContainer>
                 </a>
               </Link>
             </Fragment>

--- a/src/pages/podcast/index.js
+++ b/src/pages/podcast/index.js
@@ -94,21 +94,23 @@ export default function Podcasts({ episodes }) {
 
       <Bar height="6.25rem" />
 
-      <EpisodesContainer>
-        {episodes.map((episode, index) => (
-          <Animated amount="10px" key={index}>
-            <Fragment key={index}>
-              <Link href={`/podcast/${episode.slug}`}>
-                <a>
-                  <EpisodeContainer>
-                    <EpisodeCard episode={episode} />
-                  </EpisodeContainer>
-                </a>
-              </Link>
-            </Fragment>
-          </Animated>
-        ))}
-      </EpisodesContainer>
+      {episodes.length > 1 && (
+        <EpisodesContainer>
+          {episodes.slice(1).map((episode, index) => (
+            <Animated amount="10px" key={index}>
+              <Fragment key={index}>
+                <Link href={`/podcast/${episode.slug}`}>
+                  <a>
+                    <EpisodeContainer>
+                      <EpisodeCard episode={episode} />
+                    </EpisodeContainer>
+                  </a>
+                </Link>
+              </Fragment>
+            </Animated>
+          ))}
+        </EpisodesContainer>
+      )}
 
       <Bar />
     </>


### PR DESCRIPTION
- Spacing fixes on mobile Chrome. Flexbox `gap` doesn't seem to work there, replaced it with `margin` on the items themselves.
- Somehow the progress bar resizing is behaving weird on Firefox. Put some manual breakpoints in there to fake a responsive resizing.
- Put some spacing between `<p>`s in the episode description and also increased the line height a bit. I still don't like the look of the white box. Maybe I can think of something better in the future.
- Removed the latest episode from the episode list (since it is already featured in the player on top)