### PR TITLE
Add <hr> to show notes and fix episode cards on super small screens

### DIFF
--- a/src/components/EpisodeCard.js
+++ b/src/components/EpisodeCard.js
@@ -18,6 +18,11 @@ const Card = styled.div`
       border: 2px solid var(--orange);
     }
   }
+
+  @media (max-width: 20rem) {
+    max-width: 18rem;
+    min-width: 18rem;
+  }
 `
 
 const Content = styled.div`
@@ -46,7 +51,7 @@ const EpisodeCard = ({ episode }) => {
         <EpisodeImage src={episode.image} width={5} widthLarge={8} />
         <EpisodeDataContainer>
           <EpisodeTitle episode={episode} />
-          </EpisodeDataContainer>
+        </EpisodeDataContainer>
       </Content>
     </Card>
   )

--- a/src/lib/feed.js
+++ b/src/lib/feed.js
@@ -51,6 +51,10 @@ const sanitize = (str) => {
   return DOMPurify.sanitize(str)
 }
 
+const styledDescriptionHTML = (descr) => {
+  return descr.replace(/<p>---<\/p>/, '<hr>')
+}
+
 const parseEpisode = (e) => {
   const title = e.title.replace(/^#[0-9]* - /, '').replace(/^[\w\W]*: /, '')
   const guestMatch = e.title.replace(/^#[0-9]* - /, '').match(/^[\w\W]*: /)
@@ -62,7 +66,7 @@ const parseEpisode = (e) => {
   const duration = e['itunes:duration']
   const slug = slugify(`s${season} e${episode} ${title}`)
   const url = e['enclosure']['@_'].url
-  const descriptionHTML = sanitize(e['description'])
+  const descriptionHTML = styledDescriptionHTML(sanitize(e['description']))
   const description = stripHTML(replacements(descriptionHTML))
   const guid = e['guid']['#text']
   const value = {}

--- a/src/pages/podcast/[id].js
+++ b/src/pages/podcast/[id].js
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 import Head from 'next/head'
 
 import { fetchEpisodes } from '../../lib/feed'
-import { Text, Bar, Footer, BreezBadge } from '../../components'
+import { Text, Bar, Footer, BreezBadge, StyledLogo } from '../../components'
 
 const EpisodePlayer = dynamic(() => import('../../components/EpisodePlayer'), {
   ssr: false,
@@ -67,6 +67,7 @@ const DescriptionTextContainer = styled.div`
   }
 
   div {
+    text-align: block;
     p:not(:last-child) {
       margin: 0 0 1rem 0;
       line-height: 1.3;
@@ -74,6 +75,11 @@ const DescriptionTextContainer = styled.div`
     ul:last-child {
       margin-bottom: 0;
     }
+  }
+
+  hr {
+    border: 1px dashed var(--gray);
+    margin: 2.5rem 20%;
   }
 `
 

--- a/src/pages/podcast/[id].js
+++ b/src/pages/podcast/[id].js
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 import Head from 'next/head'
 
 import { fetchEpisodes } from '../../lib/feed'
-import { Text, Bar, Footer, BreezBadge, StyledLogo } from '../../components'
+import { Text, Bar, Footer, BreezBadge } from '../../components'
 
 const EpisodePlayer = dynamic(() => import('../../components/EpisodePlayer'), {
   ssr: false,

--- a/src/pages/podcast/[id].js
+++ b/src/pages/podcast/[id].js
@@ -79,7 +79,7 @@ const DescriptionTextContainer = styled.div`
 
   hr {
     border: 1px dashed var(--gray);
-    margin: 2.5rem 20%;
+    margin: 2.5rem 10%;
   }
 `
 


### PR DESCRIPTION
- Adds a `<hr>` between episode description and links section (see deploy preview)
- Fixes the size of episode cards on super small screens (like the iPhone SE)

When we do the blog, I'll have to come up with a better way of rendering text on black background. Then I'll apply this to the show notes as well as I still don't like the big white text box... 😅 