### PR TITLE
Fix boostagrams workflow file

### DIFF
--- a/.github/workflows/update-boostagrams.yml
+++ b/.github/workflows/update-boostagrams.yml
@@ -9,7 +9,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: seetee-io
-          ref: boostagrams
       - name: Checkout Boostagrams Repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Now that we merged to master, we need to checkout the website repo's master branch instead of the `boostagrams` feature branch. Forgot to switch that back before I merged #27.