### PR TITLE
Add ignore-boostagram workflow

### DIFF
--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -25,6 +25,7 @@ jobs:
         if: env.message_ignores
         uses: actions/checkout@v2
       - name: Checkout pull request branch
+        if: env.message_ignores
         run: git fetch && git checkout ${{ github.event.pull_request.head.ref }}
       - name: Ignore files
         id: ignoring
@@ -48,7 +49,7 @@ jobs:
           done <<< "${{ env.message_ignores }}"
           echo "::set-output name=ignored_files::$ignored_files"
       - name: Comment on pull request
-        if: steps.ignoring.outputs.ignored_files != ''
+        if: env.message_ignores && steps.ignoring.outputs.ignored_files != ''
         uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -5,12 +5,12 @@ on:
 jobs:
   ignore-boostagrams:
     name: Ignore Boostagram
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
-        github.event.review.author_association == 'COLLABORATOR' ||
-        github.event.review.author_association == 'MEMBER' ||
-        github.event.review.author_association == 'OWNER'
-      )
+    # if: |
+    #   contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
+    #     github.event.review.author_association == 'COLLABORATOR' ||
+    #     github.event.review.author_association == 'MEMBER' ||
+    #     github.event.review.author_association == 'OWNER'
+    #   )
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/debug-action@v2

--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -1,0 +1,61 @@
+name: Test Ignore Boostagram
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  ignore-boostagrams:
+    name: Ignore Boostagram
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
+        github.event.review.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'OWNER'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v2
+      - name: Check for files to ignore
+        if: contains(github.event.review.body, '/ignore')
+        run: |
+          ignores="$(echo "${{ github.event.review.body }}" | grep -e '/ignore' | sed -e 's/[[:space:]]*\/ignore[[:space:]]*[\r\n]*//')"
+          echo "message_ignores<<EOF" >> $GITHUB_ENV
+          echo "$ignores" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Clone repository
+        if: env.message_ignores
+        uses: actions/checkout@v2
+      - name: Checkout pull request branch
+        run: git fetch && git checkout ${{ github.event.pull_request.head.ref }}
+      - name: Ignore files
+        id: ignoring
+        if: env.message_ignores
+        run: |
+          ignored_files=""
+          cd src/boostagrams
+          while IFS= read -r line; do
+            line=$(echo $line | sed -e 's/[\r\n]//')
+            file="custom_records/$line.json"
+            if [ -f "$file" ]; then
+              git config --global user.name 'Seetee Bot'
+              git config --global user.email 'bot@seetee.io'
+              git rm -r --cached $file
+              echo "$file" >> .gitignore
+              git add .
+              git commit -m "Remove $line.json (automated change)"
+              git push
+              ignored_files="$ignored_files\n- \`$file\`"
+            fi
+          done <<< "${{ env.message_ignores }}"
+          echo "::set-output name=ignored_files::$ignored_files"
+      - name: Comment on pull request
+        if: steps.ignoring.outputs.ignored_files != ''
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '**🗑 Removed the following files:**\n\n${{ steps.ignoring.outputs.ignored_files }}'
+            })

--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -5,12 +5,12 @@ on:
 jobs:
   ignore-boostagrams:
     name: Ignore Boostagram
-    # if: |
-    #   contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
-    #     github.event.review.author_association == 'COLLABORATOR' ||
-    #     github.event.review.author_association == 'MEMBER' ||
-    #     github.event.review.author_association == 'OWNER'
-    #   )
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
+        github.event.review.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'OWNER'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/debug-action@v2

--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -1,10 +1,10 @@
-name: Test Ignore Boostagram
+name: Test Ignore Boostagrams
 on:
   pull_request_review:
     types: [submitted]
 jobs:
   ignore-boostagrams:
-    name: Ignore Boostagram
+    name: Ignore Boostagrams
     if: |
       contains(github.event.pull_request.labels.*.name, 'boostagram update') && (
         github.event.review.author_association == 'COLLABORATOR' ||
@@ -13,7 +13,6 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v2
       - name: Check for files to ignore
         if: contains(github.event.review.body, '/ignore')
         run: |

--- a/.github/workflows/ignore-boostagrams.yaml
+++ b/.github/workflows/ignore-boostagrams.yaml
@@ -1,4 +1,4 @@
-name: Test Ignore Boostagrams
+name: Ignore Boostagrams
 on:
   pull_request_review:
     types: [submitted]

--- a/src/boostagrams/.gitignore
+++ b/src/boostagrams/.gitignore
@@ -1,1 +1,0 @@
-custom_records/custom_record_00000.json

--- a/src/boostagrams/custom_records/custom_record_00000.json
+++ b/src/boostagrams/custom_records/custom_record_00000.json
@@ -1,0 +1,10 @@
+{
+  "podcast": "Closing the Loop",
+  "episode": "#01 - Gigi: Introduction to Closing the Loop",
+  "action": "boost",
+  "time": "00:00:00",
+  "feedID": "4058673",
+  "app_name": "Breez",
+  "value_msat_total": "110000",
+  "message": "super nice! 🙌 "
+}

--- a/src/boostagrams/custom_records/custom_record_00000.json
+++ b/src/boostagrams/custom_records/custom_record_00000.json
@@ -1,10 +1,1 @@
-{
-  "podcast": "Closing the Loop",
-  "episode": "#01 - Gigi: Introduction to Closing the Loop",
-  "action": "boost",
-  "time": "00:00:00",
-  "feedID": "4058673",
-  "app_name": "Breez",
-  "value_msat_total": "110000",
-  "message": "super nice! 🙌 "
-}
+{"podcast":"Closing the Loop","episode":"#01 - Gigi: Introduction to Closing the Loop","action":"boost","time":"00:00:00","feedID":"4058673","app_name":"Breez","value_msat_total":"110000","message":"super nice! 🙌 "}

--- a/src/boostagrams/custom_records/custom_record_00000.json
+++ b/src/boostagrams/custom_records/custom_record_00000.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#03 - Harry Sudock: Bitcoin Mining at GRIID, the Evolution of Energy Production, and Human Flourishing","action":"boost","time":"00:17:23","feedID":"4058673","app_name":"Breez","value_msat_total":"1776000","message":"You're killing it John, keep it up my friend. "}

--- a/src/boostagrams/custom_records/custom_record_00001.json
+++ b/src/boostagrams/custom_records/custom_record_00001.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#03 - Harry Sudock: Bitcoin Mining at GRIID, the Evolution of Energy Production, and Human Flourishing","action":"boost","time":"01:19:11","feedID":"4058673","app_name":"Breez","value_msat_total":"1000000","message":"Please, go get Max Hillebrand on the show!! "}

--- a/src/boostagrams/custom_records/custom_record_00002.json
+++ b/src/boostagrams/custom_records/custom_record_00002.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#06 - Whit Gibbs: Now Everyone Can Mine Bitcoin","action":"boost","time":"01:25:05","feedID":"4058673","app_name":"Breez","value_msat_total":"5000000","message":"Talk to Max! "}

--- a/src/boostagrams/custom_records/custom_record_00003.json
+++ b/src/boostagrams/custom_records/custom_record_00003.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#08 - Preston Pysh: A Once in a Millennium Opportunity","action":"boost","time":"00:00:42","feedID":"4058673","app_name":"Breez","value_msat_total":"121000","message":"Preston! 🧡"}

--- a/src/boostagrams/custom_records/custom_record_00004.json
+++ b/src/boostagrams/custom_records/custom_record_00004.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#08 - Preston Pysh: A Once in a Millennium Opportunity","action":"boost","time":"01:13:32","feedID":"4058673","app_name":"Breez","value_msat_total":"100000","message":"Whoa"}

--- a/src/boostagrams/custom_records/custom_record_00005.json
+++ b/src/boostagrams/custom_records/custom_record_00005.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#08 - Preston Pysh: A Once in a Millennium Opportunity","action":"boost","time":"01:35:19","feedID":"4058673","app_name":"Breez","value_msat_total":"100000","message":"🔥 "}

--- a/src/boostagrams/custom_records/custom_record_00006.json
+++ b/src/boostagrams/custom_records/custom_record_00006.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#08 - Preston Pysh: A Once in a Millennium Opportunity","action":"boost","time":"00:13:13","feedID":"4058673","app_name":"Breez","value_msat_total":"100000","message":"Good shit"}

--- a/src/boostagrams/custom_records/custom_record_00007.json
+++ b/src/boostagrams/custom_records/custom_record_00007.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#01 - Gigi: Introduction to Closing the Loop","action":"boost","time":"00:00:31","feedID":"4058673","app_name":"Breez","value_msat_total":"100000","message":"per episode split"}

--- a/src/boostagrams/custom_records/custom_record_00008.json
+++ b/src/boostagrams/custom_records/custom_record_00008.json
@@ -1,1 +1,0 @@
-{"podcast":"Closing the Loop","episode":"#01 - Gigi: Introduction to Closing the Loop","action":"boost","time":"00:01:02","feedID":"4058673","app_name":"Breez","value_msat_total":"500000","message":"Put this message on the website!"}


### PR DESCRIPTION
Adds a workflow that removes boostagrams when a pull request review is posted that contains the `/ignore` keyword followed by the name of the file to ignore.

For example, one could post a review with the following content:

```
/ignore custom_record_00022
/ignore custom_record_00024
/ignore custom_record_00028
```

The workflow would then automatically remove those files from the pull request branch and add them to the gitignore file.

That should make ignoring boostagrams easier and faster.

Note that only owners, members of the Seetee org or collaborators will be able to trigger this workflow to run.

---

I also removed the old boostagrams (they will get overwritten anyway so let's just start clean).