### PR TITLE
Overwrite un-merged boostagram PRs

### DIFF
--- a/.github/workflows/update-boostagrams.yml
+++ b/.github/workflows/update-boostagrams.yml
@@ -34,7 +34,6 @@ jobs:
           commit-message: Update boostagrams (automated change)
           author: Seetee Bot <bot@seetee.io>
           branch: update-boostagrams
-          branch-suffix: timestamp
           delete-branch: true
           title: 'Update Boostagrams'
           body: |


### PR DESCRIPTION
This makes the branch name for boostagram PRs non-unique. That way we shouldn't get multiple PRs in case we don't merge a boostagram update right away (c.f. the last couple of days). Instead we'll have a single PR that'll get overwritten if it doesn't get merged before the next boostagram update triggers.