### PR TITLE
Update borders and paddings

### DIFF
--- a/src/components/EpisodeCard.js
+++ b/src/components/EpisodeCard.js
@@ -5,7 +5,7 @@ import { Text, EpisodeImage, EpisodeTitle } from './'
 const Card = styled.div`
   background: rgba(255, 255, 255, 0.9);
   border: 2px solid rgba(30, 30, 30, 1);
-  border-radius: 18px;
+  border-radius: 1rem;
 
   max-width: 20rem;
   min-width: 20rem;

--- a/src/components/EpisodeImage.js
+++ b/src/components/EpisodeImage.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 const Image = styled.img`
-  border-radius: 18px;
+  border-radius: 0.7rem;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
 
   ${({ width }) => `width: ${width}rem`};
@@ -12,14 +12,7 @@ const Image = styled.img`
 `
 
 const EpisodeImage = ({ src, width, widthLarge }) => {
-  return (
-    <Image
-      src={src}
-      width={width}
-      widthLarge={widthLarge}
-      alt="Episode Cover"
-    />
-  )
+  return <Image src={src} width={width} widthLarge={widthLarge} alt="Episode Cover" />
 }
 
 export default EpisodeImage

--- a/src/components/EpisodePlayer.js
+++ b/src/components/EpisodePlayer.js
@@ -3,14 +3,7 @@ import Link from 'next/link'
 import styled from 'styled-components'
 import dateformat from 'dateformat'
 import Amplitude from 'amplitudejs'
-import ShareIcon from '../../public/share.svg'
-import {
-  Text,
-  EpisodeImage,
-  EpisodeTitle,
-  Value4Value,
-  EpisodePlayerControls,
-} from '.'
+import { Text, EpisodeImage, EpisodeTitle, Value4Value, EpisodePlayerControls } from '.'
 
 const Container = styled.div`
   display: flex;
@@ -22,33 +15,19 @@ const Container = styled.div`
   }
 `
 
-const TopContainer = styled.div`
-  padding: 0.7rem 0.5rem 0 0.7rem;
-  background: rgba(255, 255, 255, .9);
-  height: 1rem;
-  border-radius: 18px 18px 0 0;
-  display: flex;
-  justify-content flex-end;
-  align-items: center;
-`
-
-const StyledShareIcon = styled(ShareIcon)`
-  width: 1.5rem;
-  color: var(--gray);
-`
-
 const Card = styled.div`
   background: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem 1rem 0 0;
 `
 
 const CardContentContainer = styled.div`
-  padding: 0 1.2rem 1.2rem 1.2rem;
+  padding: 1rem;
   color: var(--black);
   display: flex;
   align-items: center;
 
   @media (min-width: 50rem) {
-    padding: 0 1.2rem 1.5rem 1.2rem;
+    padding: 1.3rem;
   }
 `
 
@@ -116,13 +95,6 @@ const EpisodePlayer = ({ episode, link }) => {
 
   return (
     <Container>
-      <TopContainer>
-        <Link href="https://pod.link/1578199828">
-          <a>
-            <StyledShareIcon />
-          </a>
-        </Link>
-      </TopContainer>
       {renderCard(episode, link)}
       <EpisodePlayerControls episode={episode} />
     </Container>

--- a/src/components/EpisodePlayerControls.js
+++ b/src/components/EpisodePlayerControls.js
@@ -2,10 +2,10 @@ import styled from 'styled-components'
 import Link from 'next/link'
 
 const Container = styled.div`
-  padding: 0 1rem 0 1rem;
+  padding: 0.5rem 0.8rem 0.5rem 0.8rem;
   background-color: var(--orange);
-  height: 2.5rem;
-  border-radius: 0 0 18px 18px;
+  height: 2rem;
+  border-radius: 0 0 1rem 1rem;
   display: flex;
   justify-content flex-start;
   align-items: center;
@@ -134,21 +134,16 @@ const EpisodePlayerControls = ({ episode }) => {
   return (
     <Container>
       <PlayPause className="amplitude-play-pause" />
-      <ProgressBar
-        className="amplitude-song-played-progress"
-        id="song-played-progress"
-      />
+      <ProgressBar className="amplitude-song-played-progress" id="song-played-progress" />
       <DurationDownloadContainer>
         <DurationContainer>
           <CurrentDurationContainer>
-            <span className="amplitude-current-hours"></span>:
-            <span className="amplitude-current-minutes"></span>:
+            <span className="amplitude-current-hours"></span>:<span className="amplitude-current-minutes"></span>:
             <span className="amplitude-current-seconds"></span>
           </CurrentDurationContainer>
           &nbsp;/&nbsp;
           <TotalDurationContainer>
-            <span className="amplitude-duration-hours"></span>:
-            <span className="amplitude-duration-minutes"></span>:
+            <span className="amplitude-duration-hours"></span>:<span className="amplitude-duration-minutes"></span>:
             <span className="amplitude-duration-seconds"></span>
           </TotalDurationContainer>
         </DurationContainer>

--- a/src/components/EpisodeTitle.js
+++ b/src/components/EpisodeTitle.js
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import styled from 'styled-components'
 import dateformat from 'dateformat'
 import { Text } from '.'
@@ -39,6 +40,10 @@ const TitleContainer = styled.div`
   @media (min-width: 50rem) {
     font-size: 1.1rem;
   }
+
+  a {
+    color: var(--black) !important;
+  }
 `
 
 const formatEpisodeDuration = (seconds) => {
@@ -59,9 +64,11 @@ const EpisodeTitle = ({ episode }) => {
         <Text>{dateformat(episode.date, 'dd. mmm, yyyy')}</Text>
       </MetadataContainer>
       <TitleContainer>
-        <Text>
-          {episode.guest}: {episode.title}
-        </Text>
+        <Link href="https://pod.link/1578199828">
+          <a>
+            {episode.guest}: {episode.title}
+          </a>
+        </Link>
       </TitleContainer>
     </Container>
   )


### PR DESCRIPTION
I asked a friend, who is a much better designer than I am, for feedback on our podcast website.

He recommended adapting the corner radius and padding for the episode player card which is what this PR does.
It's not much but the interplay of the nested rounded corners _does_ look better now:

### Before

<img width="108" alt="Screenshot 2022-01-03 at 15 45 57" src="https://user-images.githubusercontent.com/10026790/147944090-76728ba3-5297-44fe-9f83-5d92a3edfae5.png">

### After

<img width="136" alt="Screenshot 2022-01-03 at 15 45 16" src="https://user-images.githubusercontent.com/10026790/147943993-5b0a5feb-6398-4373-845b-3bb00307fa33.png">

---

Other than than I updated some paddings and removed the "share" icon, which wasn't really a share icon but a link to _Podlink_. The link is now on the episode title itself.