### PR TITLE
Fix loading favicon and small warnings

### DIFF
--- a/src/components/EpisodePlayerControls.js
+++ b/src/components/EpisodePlayerControls.js
@@ -116,7 +116,7 @@ const TotalDurationContainer = styled.div`
   }
 `
 
-const DownloadLink = styled.a`
+const DownloadLink = styled.span`
   font-size: 0.7rem;
 
   @media (min-width: 50rem) {

--- a/src/components/MetaHead.js
+++ b/src/components/MetaHead.js
@@ -5,7 +5,7 @@ const MetaHead = () => {
   return (
     <>
       <Head>
-        <link rel="shortcut icon" href={'favicon.ico'} />
+        <link rel="shortcut icon" href={'/favicon.ico'} />
 
         <title>{config.title}</title>
 

--- a/src/components/Value4Value.js
+++ b/src/components/Value4Value.js
@@ -51,7 +51,7 @@ const getTooltipText = (recipient, recipients) => {
 export default function Value4Value({ recipients }) {
   return (
     <Container>
-      <ReactTooltip effect="solid" place="bottom" multiline="true" />
+      <ReactTooltip effect="solid" place="bottom" multiline={true} />
       {recipients.map((r, index) => (
         <Recipient key={index} data-tip={getTooltipText(r, recipients)}>
           {r.name}


### PR DESCRIPTION
Favicon did not load correctly on subpages e.g. fetches `https://www.seetee.io/podcast/favicon.ico` on Podcast subpage, resolving to 404.