### PR TITLE
Remove review request in GitHub action

### DIFF
--- a/.github/workflows/update-boostagrams.yml
+++ b/.github/workflows/update-boostagrams.yml
@@ -66,5 +66,3 @@ jobs:
           labels: |
             automated pr
             boostagram update
-          team-reviewers: |
-            seetee-website


### PR DESCRIPTION
I think this is what's causing the occasional failed runs. The review request never worked anyway unfortunately so I'm removing it. I think we'd need to add the bot to our GitHub org for this to work properly but honestly we can also just remove the review request for now. 🤷‍♂️ 