### PR TITLE
fix: parse duration as number of seconds

### DIFF
--- a/src/components/EpisodeTitle.js
+++ b/src/components/EpisodeTitle.js
@@ -58,8 +58,12 @@ const EpisodeTitle = ({ episode }) => {
     <Container>
       <MetadataContainer>
         <Text>{episode.shortcode.split(/(?=[E])/).join(' ')}</Text>
-        <MetadataSeparator>&#8226;</MetadataSeparator>
-        <Text>{formatEpisodeDuration(episode.duration)}</Text>
+        {episode.duration >= 0 && (
+          <>
+            <MetadataSeparator>&#8226;</MetadataSeparator>
+            <Text>{formatEpisodeDuration(episode.duration)}</Text>
+          </>
+        )}
         <MetadataSeparator>&#8226;</MetadataSeparator>
         <Text>{dateformat(episode.date, 'dd. mmm, yyyy')}</Text>
       </MetadataContainer>

--- a/src/lib/feed.js
+++ b/src/lib/feed.js
@@ -58,6 +58,31 @@ const styledDescriptionHTML = (descr) => {
   return descr.replace(/<p>---<\/p>/, '<hr>')
 }
 
+/**
+ * Parse duration value and always return as "number of seconds".
+ *
+ * @param {any} rawValue expecting either "number of seconds" directly or string in format "hh:mm:ss"
+ * @return duration of episode in seconds or -1 for invalid values
+ */
+ const parseDuration = (rawValue) => {
+  if (rawValue && `${rawValue}`.includes(':')) {
+    // try parse as string with format "hh:mm:ss"
+    const splitted = `${rawValue}`.split(':')
+    if (splitted.length !== 3) return -1
+
+    const hours = parseInt(splitted[0], 10)
+    const minutes = parseInt(splitted[1], 10)
+    const seconds = parseInt(splitted[2], 10)
+
+    const isValid = !isNaN(hours) && !isNaN(minutes) && !isNaN(seconds)
+    return isValid ? hours * 3600 + minutes * 60 + seconds : -1
+  } else {
+    // try parse as string representing seconds
+    const seconds = parseInt(rawValue, 10)
+    return !isNaN(seconds) ? seconds : -1
+  }
+}
+
 const parseEpisode = (e) => {
   const title = e.title.replace(/^#[0-9]* - /, '').replace(/^[\w\W]*: /, '')
   const guestMatch = e.title.replace(/^#[0-9]* - /, '').match(/^[\w\W]*: /)
@@ -66,7 +91,7 @@ const parseEpisode = (e) => {
   const image = e['itunes:image']['@_'].href
   const season = e['itunes:season']
   const episode = e['itunes:episode']
-  const duration = e['itunes:duration']
+  const duration = parseDuration(e['itunes:duration'])
   const shortcode = `S${season}E${episode}`
   const seoSlug = slugify(`${guest} ${title}`)
   const url = e['enclosure']['@_'].url


### PR DESCRIPTION
The value of the field `<itunes:duration>` changed from number of seconds to a string formatted as "hh:mm:ss".

Both formats have to be accounted for, as newer episodes will have "hh:mm:ss", while older ones still have a number representing seconds.

e.g. `<itunes:duration>7113</itunes:duration>` vs. `<itunes:duration>02:15:23</itunes:duration>`.

Before this commit, the value displayed will be `NaNh NaNm` for newer episodes.
After this commit, the value is displayed correctly for both formats.

If the value cannot be parsed, e.g. empty or unexpected value, the duration will not be displayed.