### PR TITLE
fix: thumbnail fallback

### DIFF
--- a/src/lib/feed.js
+++ b/src/lib/feed.js
@@ -64,7 +64,7 @@ const styledDescriptionHTML = (descr) => {
  * @param {any} rawValue expecting either "number of seconds" directly or string in format "hh:mm:ss"
  * @return duration of episode in seconds or -1 for invalid values
  */
- const parseDuration = (rawValue) => {
+const parseDuration = (rawValue) => {
   if (rawValue && `${rawValue}`.includes(':')) {
     // try parse as string with format "hh:mm:ss"
     const splitted = `${rawValue}`.split(':')

--- a/src/lib/thumbnails.js
+++ b/src/lib/thumbnails.js
@@ -1,3 +1,7 @@
+import fs from 'fs'
+import path from 'path'
+
+const localPath = path.join(process.cwd(), 'public/assets/podcast/thumbnails')
 const productionPath = '/assets/podcast/thumbnails'
 const formats = ['jpg', 'webp']
 const size = 400
@@ -7,6 +11,20 @@ export function thumbnailUrlsByFormat(episode) {
   const episodeNum = episode.episode
 
   return Object.fromEntries(
-    formats.map((format) => [format, `${productionPath}/s${seasonNum}e${episodeNum}_${size}x${size}.${format}`])
+    formats
+      .map((format) => {
+        try {
+          const thumbnail = `s${seasonNum}e${episodeNum}_${size}x${size}.${format}`
+
+          if (fs.existsSync(`${localPath}/${thumbnail}`)) {
+            return [format, `${productionPath}/${thumbnail}`]
+          }
+        } catch (err) {
+          return null
+        }
+
+        return null
+      })
+      .filter((element) => element !== null)
   )
 }


### PR DESCRIPTION
Fixes an issue where even if a thumbnail was not present, it would still be included in an episodes `thumbnails` property, causing an ugly placeholder to show:

<img width="850" alt="Screenshot 2022-09-23 at 14 37 20" src="https://user-images.githubusercontent.com/111755602/191961741-ea86a8b5-a5b7-4053-9dcc-4cfd343cc19c.png">

Now, when a thumbnail is not present, the page will correctly fallback to the original (uncompressed) episode cover image:

<img width="833" alt="Screenshot 2022-09-23 at 14 38 31" src="https://user-images.githubusercontent.com/111755602/191961922-a418d1b7-a0f6-4fac-a08c-0d5bedd469b9.png">


Doesn't fix the timing issue where thumbnails might not get generated if the feed is not yet deployed but should mitigate any visible side effects.
